### PR TITLE
Adding the prefix attribute required by The Open Graph Protocol

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" prefix="og: http://ogp.me/ns#">
 <head>
   <meta charset="utf-8">
   <title>Save The Internet!</title>


### PR DESCRIPTION
Absence of this attribute to the html document, resulted in LinkedIn not showing up the text or image when the URL of index page was shared.

This attribute is documented in the first example at http://ogp.me/ :)