### PR TITLE
Sometimes changing MP results error. Fixing browser redirects to 'javascript: void(0)' in mp

### DIFF
--- a/src/mp/index.html
+++ b/src/mp/index.html
@@ -104,7 +104,7 @@
           <label for="mp-selector"><h3>Select your MP</h3></label>
           <p class="help-block">Type the name of your MP, constituency or state to search for your MP</p>
           <input type="text" class="form-control" id="mp-selector" autocomplete="off" style="font-weight: bold" placeholder="Search for your MP…">
-          <a href="javascipt:void(0)" style="display: none" id="change-mp">Change</a>
+          <a href="javascipt: void(0)" onClick="return false" style="display: none" id="change-mp">Change</a>
         </div>
         <div id="email-action">
           <button class="btn btn-info btn-lg sendResponseAuto" id="mainSend">Email <span class="mp-name"></span> now</button>


### PR DESCRIPTION
In requesting MPs page, after succesfully submitting, change the mp leads to the url `javascript:void(0)` in firefox 43, added `return false` to prevent it.