### PR TITLE
Make bcc email easier to find

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -109,9 +109,13 @@
         <div class="button-bar">
          <p><strong>TRAI has issued another consultation paper asking once again, if we want Net Neutrality. This time, it's about differential pricing - Airtel Zero and Internet.org type services.</strong></p>
         </div>
-        <button class="btn btn-info btn-lg sendResponseAuto" id="mainSend">Respond to TRAI now</button>
-          or <a href="#" class="chooseAnswers" data-toggle="collapse" data-target="#collapseContainer" id="editAnswers">edit your answers</a> (email to <strong>advisorfea1@trai.gov.in</strong> and a copy to us)
+        <div class="col-md-4">
+          <button class="btn btn-info btn-lg sendResponseAuto" id="mainSend">Respond to TRAI now</button>
+        </div>
+        <div class="col-md-8">
+          or <a href="#" class="chooseAnswers" data-toggle="collapse" data-target="#collapseContainer" id="editAnswers">edit your answers</a> (email to <strong>advisorfea1@trai.gov.in</strong> and a copy to <strong>netneutralityindia@gmail.com</strong>)
           <small><a href="javascript:void(0)" onclick="$('#policyModal').modal('show')">Privacy Policy</a></small>
+        </div>
       </div>
       <div class="col-xs-12 col-sm-6 col-md-3 col-lg-3 text-center">
         <img src="images/netneutrality.png" class="new-logo" />

--- a/src/mp/index.html
+++ b/src/mp/index.html
@@ -115,9 +115,13 @@
           <p>Know the email address for <span class="mp-name"></span>? <a id="report-unknown-email" target="_blank">Please let us know here</a></p>
         </div>
         <div id="email-action">
-          <button class="btn btn-info btn-lg sendResponseAuto" id="mainSend">Email <span class="mp-name"></span> now</button>
-            or <a href="#" class="chooseAnswers" data-toggle="collapse" data-target="#collapseContainer" id="editAnswers">edit your email</a><br>(email to <strong class="mp-email"></strong> and a copy to us)<br>
+          <div class="col-md-4">
+            <button class="btn btn-info btn-lg sendResponseAuto" id="mainSend">Email <span class="mp-name"></span> now</button>
+          </div>
+          <div class="col-md-8">
+            or <a href="#" class="chooseAnswers" data-toggle="collapse" data-target="#collapseContainer" id="editAnswers">edit your email</a><br>(email to <strong class="mp-email"></strong> and a copy to <strong>netneutralityindia@gmail.com</strong>)<br>
             <small><a href="javascript:void(0)" onclick="$('#policyModal').modal('show')">Privacy Policy</a></small>
+          </div>
         </div>
       </div>
       <div class="col-xs-12 col-sm-6 col-md-3 col-lg-3 text-center">


### PR DESCRIPTION
I sent an email without a bcc because i couldn't find it
I then looked through my old sent and picked an old
netneu...03@gmail... as the bcc

Many folks may not have this patience, i personally would
have liked to sent a bcc to the right mail. If you have found
the less number of responses - this might be reason!

PS: while going through source - i did find the email.
    so i replaced `email a copy to us`
    with `email a copy to ` the right email

preview here: http://i66.tinypic.com/b5339h.png