### PR TITLE
Better placeholder text for github issue reporting on MP page

### DIFF
--- a/src/mp/index.html
+++ b/src/mp/index.html
@@ -221,7 +221,7 @@
         <div class="col-lg-12 text-center"> 
           <p>
             <a href="https://github.com/netneutrality/" role="button" class="btn btn-sm btn-info">Made with ♥ by folks just like you</a>
-            <a href="https://github.com/netneutrality/savetheinternet.in/issues/new?title=Please+enter+the+name+of+the+MP+here&body=Please+paste+the+body+of+the+error+email+message+that+you+get+here%E2%80%A6" role="button" class="btn btn-sm btn-warning" target="_blank">Report bouncing email addresses</a>
+            <a href="https://github.com/netneutrality/savetheinternet.in/issues/new?title=Please+enter+the+name+of+the+MP+here&body=For+the+email+address(es)+that+have+bounced,+please+provide+us+the+following+by+copy-pasting+it+from+the+Failure+Delivery+Notification+email+that+you+have+received:%0A%0A+Technical+details+of+permanent+failure:%0A%0A+The+error+that+the+server+returned:%0A%0A" role="button" class="btn btn-sm btn-warning" target="_blank">Report bouncing email addresses</a>
         </div>
       </div>
     </div>

--- a/src/mp/index.html
+++ b/src/mp/index.html
@@ -221,7 +221,7 @@
         <div class="col-lg-12 text-center"> 
           <p>
             <a href="https://github.com/netneutrality/" role="button" class="btn btn-sm btn-info">Made with ♥ by folks just like you</a>
-            <a href="https://github.com/netneutrality/savetheinternet.in/issues/new?title=Please+enter+the+name+of+the+MP+here&body=Please+type+the+details+of+the+bounced+email+address(es)+here%E2%80%A6" role="button" class="btn btn-sm btn-warning" target="_blank">Report bouncing email addresses</a>
+            <a href="https://github.com/netneutrality/savetheinternet.in/issues/new?title=Please+enter+the+name+of+the+MP+here&body=Please+paste+the+body+of+the+error+email+message+that+you+get+here%E2%80%A6" role="button" class="btn btn-sm btn-warning" target="_blank">Report bouncing email addresses</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Many users just report the email address that has problems and don't tell us the exact problem with email address. I have changed the placeholder text for the body of the Github issue, asking people to paste the body of the error email that they get. It includes the problematic email address, by default.