### PR TITLE
Fixed typo: 'misrepresented' from misprepresented

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -334,7 +334,7 @@
               <ul>
               <li><a href="http://blog.savetheinternet.in/what-facebook-wont-tell-you-about-freebasics/">What Facebook won't tell you about FreeBasics</a></li>
               <li><a href="http://blog.savetheinternet.in/trai-suspend-free-basics/">Statement on TRAI's order that Reliance temporarily suspend Free Basics</a></li>
-              <li><a href="http://blog.savetheinternet.in/if-youve-been-misled-by-facebook/">If you've been misprepresented by Facebook</a></li>
+              <li><a href="http://blog.savetheinternet.in/if-youve-been-misled-by-facebook/">If you've been misrepresented by Facebook</a></li>
               </ul>
               <p class="text-right"><a href="http://blog.savetheinternet.in/">Visit Blog &raquo;</a></p>
             </div>


### PR DESCRIPTION
I think the intended word for the article is 'misrepresented'