### PR TITLE
Fixed email addresses in fb-trail 'submit response' section.

### DIFF
--- a/src/fb-trai/index.html
+++ b/src/fb-trai/index.html
@@ -191,7 +191,7 @@
   <footer>
     <div class="container">
       <div class="row">
-        <div class="col-lg-12 text-center"> 
+        <div class="col-lg-12 text-center">
           <p>
             <a href="https://github.com/netneutrality/" role="button" class="btn btn-sm btn-info">Made with ♥ by folks just like you</a>
         </div>
@@ -229,8 +229,9 @@
               </p>
                 <p>You will be able to edit before you send.</p>
                 </div>
-                <p>Emails should be sent to <strong><span class="text-info">advisorfea1@trai.gov.in</span></strong><br />
-                Please bcc us at <strong><span class="text-info" id="bccAddressModal">netneutralityindia@gmail.com</span></strong><br />
+                <p>Emails should be sent to <strong><span class="text-info">ankhi@fb.com</span></strong><br />
+                CC TRAI at <strong><span class="text-info">advisorfea1@trai.gov.in</span></strong>
+                and to us at<br /> <strong><span class="text-info">fb-trai@email.savetheinternet.in</span></strong><br /><br />
                 We will try to ensure that your response is acknowledged by TRAI.</p>
               </div>
           </div>


### PR DESCRIPTION
It was set to `advisorfea1@trai.gov.in`.
Changed it to `ankhi@fb.com` and for CC added  `advisorfea1@trai.gov.in` & `fb-trai@email.savetheinternet.in`

Also, removed `netneutralityindia@gmail.com` from BCC (wasn't sure about this)

Screenshot
![screen shot 2016-01-19 at 16 42 35](https://cloud.githubusercontent.com/assets/4872139/12417163/0a203c18-becc-11e5-8737-43fd85a2bd2f.png)
